### PR TITLE
Create sdk version upload action

### DIFF
--- a/.github/workflows/test-upload-sdk-version.yml
+++ b/.github/workflows/test-upload-sdk-version.yml
@@ -1,0 +1,31 @@
+name: Test Upload SDK Version Action
+
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: "Target platform (ios, android, flutter, reactnative, unity)"
+        required: true
+        default: ios
+      version:
+        description: "SDK version to publish"
+        required: true
+        default: 1.2.3
+      dryRun:
+        description: "Dry run (true/false)"
+        required: false
+        default: "true"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test action from commit
+        uses: embrace-io/public-actions/upload-sdk-version@v1 # testing the latest
+        with:
+          platform: {{ inputs.platform }}
+          version: {{ inputs.version }}
+          dryRun: {{ inputs.dryRun }}
+          sdkVersionUrl: ${{ vars.SDK_VERSION_URL }}
+        env:
+          SDK_VERSION_TOKEN: ${{ secrets.SDK_VERSION_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # Embrace Public Actions
+This repository contains reusable GitHub Actions for Embrace related workflows.
+
+## Available Actions
+
+- [`upload-sdk-version`](./upload-sdk-version): Validates and uploads a version to the Embrace dashboard.
+ 
+

--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+HELP_TEXT=$(cat <<'EOF'
+tag-release.sh — Create semantic version tags for Embraces GitHub Actions
+
+This script helps version GitHub Actions using a pattern similar to actions/checkout@v4.
+
+It performs:
+1. A full semantic tag like `v1.2.3`, which is immutable and meant for exact version pinning.
+2. A major version tag like `v1`, which is force-updated to always point to the latest `v1.x.x`.
+
+Usage:
+  ./tag-release.sh 1.2.3
+
+Result:
+  - Tags `v1.2.3`
+  - Force-updates `v1` to point to the same commit
+
+This allows workflows to choose between:
+  - uses: embrace-io/upload-sdk-version@v1       (latest stable v1.x)
+  - uses: embrace-io/upload-sdk-version@v1.2.3   (specific pinned version)
+EOF
+)
+
+if [[ $# -lt 1 || "$1" == "--help" || "$1" == "-h" ]]; then
+  echo "$HELP_TEXT"
+  exit 0
+fi
+
+set -euo pipefail
+
+FULL_VERSION="$1"
+MAJOR_VERSION="v$(echo "$FULL_VERSION" | cut -d. -f1)"
+FULL_TAG="v$FULL_VERSION"
+
+echo "Creating tag $FULL_TAG and updating $MAJOR_VERSION..."
+
+git tag "$FULL_TAG"
+git tag -f "$MAJOR_VERSION"
+git push origin "$FULL_TAG"
+git push -f origin "$MAJOR_VERSION"
+
+echo "Done. Tags pushed:"
+echo "- $FULL_TAG"
+echo "- $MAJOR_VERSION aimint to → $FULL_TAG"

--- a/upload-sdk-version/README.md
+++ b/upload-sdk-version/README.md
@@ -4,16 +4,16 @@ This GitHub Action validates and publishes an SDK version for a given platform t
 
 ## Parameters
 
-| Name       | Required | Description                                                                 |
-|------------|----------|-----------------------------------------------------------------------------|
-| `platform` | ✅       | Target platform: `ios`, `android`, `rn`, `flutter`, or `unity`.             |
-| `version`  | ✅       | The version string to publish                                               |
-| `dryRun`   | ❌       | If `true`, only validates the token without publishing. Default: `false`.   |
+| Name              | Required | Description                                                                 |
+|-------------------|----------|-----------------------------------------------------------------------------|
+| `platform`        | ✅       | Target platform: `ios`, `android`, `rn`, `flutter`, or `unity`.             |
+| `version`         | ✅       | The version string to publish                                               |
+| `dryRun`          | ❌       | If `true`, only validates the token without publishing. Default: `false`.   |
+| `sdkVersionUrl`   | ✅       | Base URL for SDK version publishing.                                        |
 
-## Secrets / Variables
+## Environment Variables
 
-- `secrets.SDK_VERSION_TOKEN`: Token used to authenticate requests to the versioning backend.
-- `vars.SDK_VERSION_URL`: Base URL of the dashboard that will handle the SDK versioning.
+- `SDK_VERSION_TOKEN`: Token used to authenticate requests to the versioning backend.
 
 ## How to use
 
@@ -24,8 +24,7 @@ This GitHub Action validates and publishes an SDK version for a given platform t
     platform: ios
     version: 1.2.3
     dryRun: false
-  secrets:
-    SDK_VERSION_TOKEN: ${{ secrets.SDK_VERSION_TOKEN }}
+    sdkVersionUrl: ${{ vars.SDK_VERSION_URL }}
   env:
-    SDK_VERSION_URL: ${{ vars.SDK_VERSION_URL }}
+    SDK_VERSION_TOKEN: ${{ secrets.SDK_VERSION_TOKEN }}
 ```

--- a/upload-sdk-version/README.md
+++ b/upload-sdk-version/README.md
@@ -6,7 +6,7 @@ This GitHub Action validates and publishes an SDK version for a given platform t
 
 | Name       | Required | Description                                                                 |
 |------------|----------|-----------------------------------------------------------------------------|
-| `platform` | ✅       | Target platform: `ios`, `android`, `flutter`, `reactnative`, or `unity`.    |
+| `platform` | ✅       | Target platform: `ios`, `android`, `rn`, `flutter`, or `unity`.             |
 | `version`  | ✅       | The version string to publish                                               |
 | `dry-run`  | ❌       | If `true`, only validates the token without publishing. Default: `false`.   |
 

--- a/upload-sdk-version/README.md
+++ b/upload-sdk-version/README.md
@@ -1,0 +1,31 @@
+# Upload SDK Version
+
+This GitHub Action validates and publishes an SDK version for a given platform to the Embrace dashboard.
+
+## Parameters
+
+| Name       | Required | Description                                                                 |
+|------------|----------|-----------------------------------------------------------------------------|
+| `platform` | ✅       | Target platform: `ios`, `android`, `flutter`, `reactnative`, or `unity`.    |
+| `version`  | ✅       | The version string to publish                                               |
+| `dry-run`  | ❌       | If `true`, only validates the token without publishing. Default: `false`.   |
+
+## Secrets / Variables
+
+- `secrets.SDK_VERSION_TOKEN`: Token used to authenticate requests to the versioning backend.
+- `vars.SDK_VERSION_URL`: Base URL of the dashboard that will handle the SDK versioning.
+
+## How to use
+
+```yaml
+- name: Upload SDK version to Embrace
+  uses: embrace-io/sdk-actions/upload-sdk-version@v1
+  with:
+    platform: ios
+    version: 1.2.3
+    dry-run: false
+  secrets:
+    SDK_VERSION_TOKEN: ${{ secrets.SDK_VERSION_TOKEN }}
+  env:
+    SDK_VERSION_URL: ${{ vars.SDK_VERSION_URL }}
+```

--- a/upload-sdk-version/README.md
+++ b/upload-sdk-version/README.md
@@ -8,7 +8,7 @@ This GitHub Action validates and publishes an SDK version for a given platform t
 |------------|----------|-----------------------------------------------------------------------------|
 | `platform` | ✅       | Target platform: `ios`, `android`, `rn`, `flutter`, or `unity`.             |
 | `version`  | ✅       | The version string to publish                                               |
-| `dry-run`  | ❌       | If `true`, only validates the token without publishing. Default: `false`.   |
+| `dryRun`   | ❌       | If `true`, only validates the token without publishing. Default: `false`.   |
 
 ## Secrets / Variables
 
@@ -23,7 +23,7 @@ This GitHub Action validates and publishes an SDK version for a given platform t
   with:
     platform: ios
     version: 1.2.3
-    dry-run: false
+    dryRun: false
   secrets:
     SDK_VERSION_TOKEN: ${{ secrets.SDK_VERSION_TOKEN }}
   env:

--- a/upload-sdk-version/action.yml
+++ b/upload-sdk-version/action.yml
@@ -16,6 +16,9 @@ inputs:
     description: "If true, validates if the request should and could be done"
     required: false
     default: 'false'
+  sdkVersionUrl:
+    description: "Base URL for SDK version publishing"
+    required: true
 
 runs:
   using: "composite"
@@ -33,17 +36,17 @@ runs:
       if: inputs.dryRun == 'true'
       shell: bash
       run: |
-        echo "🔍 Validating token with SDK_VERSION_URL=${{ vars.SDK_VERSION_URL }}"
-        curl -f "${{ vars.SDK_VERSION_URL }}/check-token/" \
-          -H "X-Embrace-CI: ${{ secrets.SDK_VERSION_TOKEN }}"
+        echo "Validating token"
+        curl -f "${{ inputs.sdkVersionUrl }}/check-token/" \
+          -H "X-Embrace-CI: $SDK_VERSION_TOKEN"
 
     - name: Publish version
       if: inputs.dryRun != 'true'
       shell: bash
       run: |
         echo "Publishing the version ${{ inputs.version }} for the ${{ inputs.platform }} SDK"
-        curl -f -X POST "${{ vars.SDK_VERSION_URL }}/${{ inputs.platform }}/version/" \
-          -H "X-Embrace-CI: ${{ secrets.SDK_VERSION_TOKEN }}" \
+        curl -f -X POST "${{ inputs.sdkVersionUrl }}/${{ inputs.platform }}/version/" \
+          -H "X-Embrace-CI: $SDK_VERSION_TOKEN" \
           -H "Content-Type: application/json" \
           -d '{"version": "${{ inputs.version }}"}'
 

--- a/upload-sdk-version/action.yml
+++ b/upload-sdk-version/action.yml
@@ -12,7 +12,7 @@ inputs:
   version:
     description: "SDK version to upload"
     required: true
-  dry-run:
+  dryRun:
     description: "If true, validates if the request should and could be done"
     required: false
     default: 'false'
@@ -29,8 +29,8 @@ runs:
           exit 1
         fi
 
-    - name: Validate token (dry-run)
-      if: inputs.dry-run == 'true'
+    - name: Validate token (dry run)
+      if: inputs.dryRun == 'true'
       shell: bash
       run: |
         echo "🔍 Validating token with SDK_VERSION_URL=${{ vars.SDK_VERSION_URL }}"
@@ -38,7 +38,7 @@ runs:
           -H "X-Embrace-CI: ${{ secrets.SDK_VERSION_TOKEN }}"
 
     - name: Publish version
-      if: inputs.dry-run != 'true'
+      if: inputs.dryRun != 'true'
       shell: bash
       run: |
         echo "Publishing the version ${{ inputs.version }} for the ${{ inputs.platform }} SDK"

--- a/upload-sdk-version/action.yml
+++ b/upload-sdk-version/action.yml
@@ -1,0 +1,49 @@
+name: "Upload SDK Version"
+description: "Validates and/or uploads the SDK version to the Embrace Dashboard"
+
+branding:
+  icon: "tag"
+  color: "yellow"
+
+inputs:
+  platform:
+    description: "Platform: ios, android, flutter, rn, unity"
+    required: true
+  version:
+    description: "SDK version to upload"
+    required: true
+  dry-run:
+    description: "If true, validates if the request should and could be done"
+    required: false
+    default: 'false'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate platform
+      shell: bash
+      run: |
+        VALID_PLATFORMS=(ios android flutter rn unity)
+        if [[ ! " ${VALID_PLATFORMS[@]} " =~ " ${{ inputs.platform }} " ]]; then
+          echo "Invalid platform: ${{ inputs.platform }}"
+          exit 1
+        fi
+
+    - name: Validate token (dry-run)
+      if: inputs.dry-run == 'true'
+      shell: bash
+      run: |
+        echo "🔍 Validating token with SDK_VERSION_URL=${{ vars.SDK_VERSION_URL }}"
+        curl -f "${{ vars.SDK_VERSION_URL }}/check-token/" \
+          -H "X-Embrace-CI: ${{ secrets.SDK_VERSION_TOKEN }}"
+
+    - name: Publish version
+      if: inputs.dry-run != 'true'
+      shell: bash
+      run: |
+        echo "Publishing the version ${{ inputs.version }} for the ${{ inputs.platform }} SDK"
+        curl -f -X POST "${{ vars.SDK_VERSION_URL }}/${{ inputs.platform }}/version/" \
+          -H "X-Embrace-CI: ${{ secrets.SDK_VERSION_TOKEN }}" \
+          -H "Content-Type: application/json" \
+          -d '{"version": "${{ inputs.version }}"}'
+


### PR DESCRIPTION
# Overview
- Created `upload-sdk-version` action
- Created a workflow (`test-upload-sdk-version`) to test the action.
- Created a script (`tag-release.sh`) to do the release of the action in a similar way official github actions (like [checkout](https://github.com/actions)) are tagged / released.
- Added main `README` and a specific one for the `upload-sdk-version` action.